### PR TITLE
Used Kleisli to pass a context

### DIFF
--- a/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/FutureStorageDriver.scala
+++ b/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/FutureStorageDriver.scala
@@ -1,8 +1,0 @@
-package com.github.j5ik2o.scala.ddd.functional.cats
-
-import scala.concurrent.Future
-
-trait FutureStorageDriver extends StorageDriver {
-  override type DSL[A]              = Future[A]
-  override type SingleResultType[A] = Option[A]
-}

--- a/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/StorageDriver.scala
+++ b/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/StorageDriver.scala
@@ -7,5 +7,5 @@ trait StorageDriver extends AggregateRepository with AggregateDeletable {
 
   protected def convertToRecord(aggregate: AggregateType): RecordType
 
-  protected def convertToAggregate(record: SingleResultType[RecordType]): SingleResultType[AggregateType]
+  protected def convertToAggregate(record: Option[RecordType]): Option[AggregateType]
 }

--- a/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/driver/FreeIODeleteFeature.scala
+++ b/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/driver/FreeIODeleteFeature.scala
@@ -8,7 +8,7 @@ trait FreeIODeleteFeature extends FreeIOBaseFeature with FreeIOWriteFeature with
 
   import com.github.j5ik2o.scala.ddd.functional.AggregateRepositoryDSL._
 
-  override def deleteById(id: AggregateIdType)(implicit ec: IOContextType): DSL[Unit] =
+  override def deleteById(id: AggregateIdType): DSL[Unit] =
     Free.liftF[AggregateRepositoryDSL, Unit](Delete(id))
 
 }

--- a/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/driver/FreeIOReadFeature.scala
+++ b/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/driver/FreeIOReadFeature.scala
@@ -8,11 +8,9 @@ trait FreeIOReadFeature extends FreeIOBaseFeature with AggregateReader {
 
   import com.github.j5ik2o.scala.ddd.functional.AggregateRepositoryDSL._
 
-  override type SingleResultType[A] = Option[A]
-
   override def resolveBy(
       id: AggregateIdType
-  )(implicit ctx: IOContextType): DSL[SingleResultType[AggregateType]] =
-    Free.liftF[AggregateRepositoryDSL, SingleResultType[AggregateType]](ResolveById(id))
+  ): DSL[Option[AggregateType]] =
+    Free.liftF[AggregateRepositoryDSL, Option[AggregateType]](ResolveById(id))
 
 }

--- a/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/driver/FreeIOWriteFeature.scala
+++ b/cats/src/main/scala/com/github/j5ik2o/scala/ddd/functional/cats/driver/FreeIOWriteFeature.scala
@@ -8,7 +8,7 @@ trait FreeIOWriteFeature extends FreeIOBaseFeature with AggregateWriter {
 
   import com.github.j5ik2o.scala.ddd.functional.AggregateRepositoryDSL._
 
-  override def store(aggregate: AggregateType)(implicit ctx: IOContextType): DSL[Unit] =
+  override def store(aggregate: AggregateType): DSL[Unit] =
     Free.liftF[AggregateRepositoryDSL, Unit](Store(aggregate))
 
 }

--- a/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/AggregateFutureIOContext.scala
+++ b/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/AggregateFutureIOContext.scala
@@ -1,7 +1,0 @@
-package com.github.j5ik2o.scala.ddd.functional
-
-import scala.concurrent.ExecutionContext
-
-trait AggregateFutureIOContext extends AggregateIOContext {
-  val ec: ExecutionContext
-}

--- a/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/AggregateIOContext.scala
+++ b/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/AggregateIOContext.scala
@@ -1,3 +1,0 @@
-package com.github.j5ik2o.scala.ddd.functional
-
-trait AggregateIOContext

--- a/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/driver/AggregateDeletable.scala
+++ b/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/driver/AggregateDeletable.scala
@@ -2,6 +2,6 @@ package com.github.j5ik2o.scala.ddd.functional.driver
 
 trait AggregateDeletable { this: AggregateWriter =>
 
-  def deleteById(id: AggregateIdType)(implicit ctx: IOContextType): DSL[Unit]
+  def deleteById(id: AggregateIdType): DSL[Unit]
 
 }

--- a/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/driver/AggregateIO.scala
+++ b/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/driver/AggregateIO.scala
@@ -13,5 +13,4 @@ trait AggregateIO { self =>
     type AggregateType = self.AggregateType
   }
   type DSL[_]
-  type IOContextType
 }

--- a/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/driver/AggregateReader.scala
+++ b/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/driver/AggregateReader.scala
@@ -2,8 +2,6 @@ package com.github.j5ik2o.scala.ddd.functional.driver
 
 trait AggregateReader extends AggregateIO {
 
-  type SingleResultType[_]
-
-  def resolveBy(id: AggregateIdType)(implicit ctx: IOContextType): DSL[SingleResultType[AggregateType]]
+  def resolveBy(id: AggregateIdType): DSL[Option[AggregateType]]
 
 }

--- a/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/driver/AggregateWriter.scala
+++ b/core/src/main/scala/com/github/j5ik2o/scala/ddd/functional/driver/AggregateWriter.scala
@@ -2,6 +2,6 @@ package com.github.j5ik2o.scala.ddd.functional.driver
 
 trait AggregateWriter extends AggregateIO {
 
-  def store(aggregate: AggregateType)(implicit ctx: IOContextType): DSL[Unit]
+  def store(aggregate: AggregateType): DSL[Unit]
 
 }

--- a/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/domain/skinnyorm/UserSkinnyORMFutureEvaluator.scala
+++ b/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/domain/skinnyorm/UserSkinnyORMFutureEvaluator.scala
@@ -1,5 +1,6 @@
 package com.github.j5ik2o.scala.ddd.functional.example.domain.skinnyorm
 
+import cats.data.Kleisli
 import com.github.j5ik2o.scala.ddd.functional.cats.driver.FreeIOEvaluator
 import com.github.j5ik2o.scala.ddd.functional.example.domain.{ User, UserId }
 import com.github.j5ik2o.scala.ddd.functional.example.driver.skinnyorm.UserSkinnyORMFutureStorageDriver
@@ -7,11 +8,11 @@ import com.github.j5ik2o.scala.ddd.functional.skinnyorm.SkinnyORMFutureIOContext
 
 import scala.concurrent.Future
 
-case class UserSkinnyORMFutureEvaluator(override val driver: UserSkinnyORMFutureStorageDriver) extends FreeIOEvaluator {
-  override type EvalType[A]     = Future[A]
+case class UserSkinnyORMFutureEvaluator(override val driver: UserSkinnyORMFutureStorageDriver)
+    extends FreeIOEvaluator {
+  override type EvalType[A]     = Kleisli[Future, SkinnyORMFutureIOContext, A]
   override type DriverType      = UserSkinnyORMFutureStorageDriver
   override type IdValueType     = Long
   override type AggregateIdType = UserId
   override type AggregateType   = User
-  override type IOContextType   = SkinnyORMFutureIOContext
 }

--- a/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/domain/slick/UserSlickDBIOEvaluator.scala
+++ b/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/domain/slick/UserSlickDBIOEvaluator.scala
@@ -1,15 +1,16 @@
 package com.github.j5ik2o.scala.ddd.functional.example.domain.slick
 
+import cats.data.Kleisli
 import com.github.j5ik2o.scala.ddd.functional.cats.driver.FreeIOEvaluator
 import com.github.j5ik2o.scala.ddd.functional.example.domain.{ User, UserId }
 import com.github.j5ik2o.scala.ddd.functional.example.driver.slick3.UserSlickDBIOStorageDriver
-import com.github.j5ik2o.scala.ddd.functional.slick.SlickFutureIOContext
+
+import scala.concurrent.ExecutionContext
 
 case class UserSlickDBIOEvaluator(override val driver: UserSlickDBIOStorageDriver) extends FreeIOEvaluator {
-  override type EvalType[A]     = driver.profile.api.DBIO[A]
+  override type EvalType[A]     = Kleisli[driver.profile.api.DBIO, ExecutionContext, A]
   override type DriverType      = UserSlickDBIOStorageDriver
   override type IdValueType     = Long
   override type AggregateIdType = UserId
   override type AggregateType   = User
-  override type IOContextType   = SlickFutureIOContext
 }

--- a/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/domain/slick/UserSlickFutureEvaluator.scala
+++ b/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/domain/slick/UserSlickFutureEvaluator.scala
@@ -1,17 +1,16 @@
 package com.github.j5ik2o.scala.ddd.functional.example.domain.slick
 
+import cats.data.Kleisli
 import com.github.j5ik2o.scala.ddd.functional.cats.driver.FreeIOEvaluator
 import com.github.j5ik2o.scala.ddd.functional.example.domain.{ User, UserId }
 import com.github.j5ik2o.scala.ddd.functional.example.driver.slick3.UserSlickFutureStorageDriver
-import com.github.j5ik2o.scala.ddd.functional.slick.SlickFutureIOContext
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 case class UserSlickFutureEvaluator(override val driver: UserSlickFutureStorageDriver) extends FreeIOEvaluator {
-  override type EvalType[A]     = Future[A]
+  override type EvalType[A]     = Kleisli[Future, ExecutionContext, A]
   override type DriverType      = UserSlickFutureStorageDriver
   override type IdValueType     = Long
   override type AggregateIdType = UserId
   override type AggregateType   = User
-  override type IOContextType   = SlickFutureIOContext
 }

--- a/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/driver/UserFutureStorageDriver.scala
+++ b/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/driver/UserFutureStorageDriver.scala
@@ -1,9 +1,9 @@
 package com.github.j5ik2o.scala.ddd.functional.example.driver
 
-import com.github.j5ik2o.scala.ddd.functional.cats.FutureStorageDriver
+import com.github.j5ik2o.scala.ddd.functional.cats.StorageDriver
 import com.github.j5ik2o.scala.ddd.functional.example.domain.{ User, UserId }
 
-trait UserFutureStorageDriver extends FutureStorageDriver {
+trait UserFutureStorageDriver extends StorageDriver {
   override type IdValueType     = Long
   override type AggregateIdType = UserId
   override type AggregateType   = User

--- a/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/driver/slick3/UserSlickFutureStorageDriver.scala
+++ b/example/src/main/scala/com/github/j5ik2o/scala/ddd/functional/example/driver/slick3/UserSlickFutureStorageDriver.scala
@@ -15,7 +15,6 @@ case class UserSlickFutureStorageDriver(profile: JdbcProfile, db: JdbcProfile#Ba
   override type RecordType      = UserRecord
   override type TableType       = UserDef
   override protected val dao = UserDao
-  override type SingleResultType[A] = Option[A]
 
   override protected def convertToRecord(aggregate: User): UserRecord =
     UserRecord(id = aggregate.id.value, name = aggregate.name)

--- a/skinny-orm/src/main/scala/com/github/j5ik2o/scala/ddd/functional/skinnyorm/SkinnyORMFutureIOContext.scala
+++ b/skinny-orm/src/main/scala/com/github/j5ik2o/scala/ddd/functional/skinnyorm/SkinnyORMFutureIOContext.scala
@@ -1,8 +1,7 @@
 package com.github.j5ik2o.scala.ddd.functional.skinnyorm
 
-import com.github.j5ik2o.scala.ddd.functional.AggregateFutureIOContext
 import scalikejdbc.DBSession
 
 import scala.concurrent.ExecutionContext
 
-case class SkinnyORMFutureIOContext(ec: ExecutionContext, dBSession: DBSession) extends AggregateFutureIOContext
+case class SkinnyORMFutureIOContext(ec: ExecutionContext, dBSession: DBSession)

--- a/slick/src/main/scala/com/github/j5ik2o/scala/ddd/functional/slick/SlickDBIOStorageDriver.scala
+++ b/slick/src/main/scala/com/github/j5ik2o/scala/ddd/functional/slick/SlickDBIOStorageDriver.scala
@@ -1,34 +1,35 @@
 package com.github.j5ik2o.scala.ddd.functional.slick
 
+import cats.data.Kleisli
+
+import scala.concurrent.ExecutionContext
+
 trait SlickDBIOStorageDriver extends SlickStorageDriver {
   import profile.api._
-  override type DSL[_]        = DBIO[_]
-  override type IOContextType = SlickFutureIOContext
 
-  override def store(aggregate: AggregateType)(implicit ctx: IOContextType): DSL[Unit] = {
-    implicit val ec = ctx.ec
-    val record      = convertToRecord(aggregate)
+  override type DSL[_] = Kleisli[DBIO, ExecutionContext, _]
+
+  override def store(aggregate: AggregateType): DSL[Unit] = Kleisli { implicit ec =>
+    val record = convertToRecord(aggregate)
     val action = (for {
       n <- dao.filter(_.id === aggregate.id.value).update(record)
       _ <- if (n == 0) dao.forceInsert(record) else DBIO.successful(n)
     } yield ()).transactionally
-    action.asInstanceOf[DSL[Unit]]
+    action.asInstanceOf[DBIO[Unit]]
   }
 
-  override def resolveBy(id: AggregateIdType)(implicit ctx: IOContextType): DSL[Option[AggregateType]] = {
-    implicit val ec = ctx.ec
+  override def resolveBy(id: AggregateIdType): DSL[Option[AggregateType]] = Kleisli { implicit ec =>
     val action =
       dao
         .filter(_.id === id.value)
         .result
         .headOption
         .map(convertToAggregate)
-    action.asInstanceOf[DSL[Option[AggregateType]]]
+    action.asInstanceOf[DBIO[Option[AggregateType]]]
   }
 
-  override def deleteById(id: AggregateIdType)(implicit ctx: IOContextType): DSL[Unit] = {
-    implicit val ec = ctx.ec
-    val action      = dao.filter(_.id === id.value).delete
+  override def deleteById(id: AggregateIdType): DSL[Unit] = Kleisli { implicit ec =>
+    val action = dao.filter(_.id === id.value).delete
     action
       .flatMap { v =>
         if (v == 1)
@@ -36,7 +37,7 @@ trait SlickDBIOStorageDriver extends SlickStorageDriver {
         else
           DBIO.failed(new Exception())
       }
-      .asInstanceOf[DSL[Unit]]
+      .asInstanceOf[DBIO[Unit]]
   }
 
 }

--- a/slick/src/main/scala/com/github/j5ik2o/scala/ddd/functional/slick/SlickFutureIOContext.scala
+++ b/slick/src/main/scala/com/github/j5ik2o/scala/ddd/functional/slick/SlickFutureIOContext.scala
@@ -1,7 +1,0 @@
-package com.github.j5ik2o.scala.ddd.functional.slick
-
-import com.github.j5ik2o.scala.ddd.functional.AggregateFutureIOContext
-
-import scala.concurrent.ExecutionContext
-
-case class SlickFutureIOContext(ec: ExecutionContext) extends AggregateFutureIOContext

--- a/slick/src/main/scala/com/github/j5ik2o/scala/ddd/functional/slick/SlickFutureStorageDriver.scala
+++ b/slick/src/main/scala/com/github/j5ik2o/scala/ddd/functional/slick/SlickFutureStorageDriver.scala
@@ -1,14 +1,19 @@
 package com.github.j5ik2o.scala.ddd.functional.slick
 
-import com.github.j5ik2o.scala.ddd.functional.cats.FutureStorageDriver
+import cats.data.Kleisli
+import com.github.j5ik2o.scala.ddd.functional.cats.StorageDriver
 
-trait SlickFutureStorageDriver extends FutureStorageDriver with SlickStorageDriver {
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait SlickFutureStorageDriver extends StorageDriver with SlickStorageDriver {
+
   import profile.api._
-  override type IOContextType = SlickFutureIOContext
 
-  override def store(aggregate: AggregateType)(implicit ctx: IOContextType): DSL[Unit] = {
-    implicit val ec = ctx.ec
-    val record      = convertToRecord(aggregate)
+  //  override type IOContextType = SlickFutureIOContext
+  override type DSL[A] = Kleisli[Future, ExecutionContext, A]
+
+  override def store(aggregate: AggregateType): DSL[Unit] = Kleisli { implicit ec =>
+    val record = convertToRecord(aggregate)
     val action = (for {
       n <- dao.filter(_.id === aggregate.id.value).update(record)
       _ <- if (n == 0) dao.forceInsert(record) else DBIO.successful(n)
@@ -16,8 +21,7 @@ trait SlickFutureStorageDriver extends FutureStorageDriver with SlickStorageDriv
     db.run(action)
   }
 
-  override def resolveBy(id: AggregateIdType)(implicit ctx: IOContextType): DSL[Option[AggregateType]] = {
-    implicit val ec = ctx.ec
+  override def resolveBy(id: AggregateIdType): DSL[Option[AggregateType]] = Kleisli { implicit ec =>
     val action =
       dao
         .filter(_.id === id.value)
@@ -27,18 +31,16 @@ trait SlickFutureStorageDriver extends FutureStorageDriver with SlickStorageDriv
     db.run(action)
   }
 
-  override def deleteById(id: AggregateIdType)(implicit ctx: IOContextType): DSL[Unit] = {
-    implicit val ec = ctx.ec
-    val action      = dao.filter(_.id === id.value).delete
+  override def deleteById(id: AggregateIdType): DSL[Unit] = Kleisli { implicit ec =>
+    val action = dao.filter(_.id === id.value).delete
     db.run(
-        action
-          .flatMap { v =>
-            if (v == 1)
-              DBIO.successful(())
-            else
-              DBIO.failed(new Exception())
-          }
-      )
-      .asInstanceOf[DSL[Unit]]
+      action
+        .flatMap { v =>
+          (if (v == 1)
+             DBIO.successful(())
+           else
+             DBIO.failed(new Exception())): DBIO[Unit]
+        }
+    )
   }
 }

--- a/slick/src/main/scala/com/github/j5ik2o/scala/ddd/functional/slick/SlickStorageDriver.scala
+++ b/slick/src/main/scala/com/github/j5ik2o/scala/ddd/functional/slick/SlickStorageDriver.scala
@@ -13,7 +13,6 @@ trait SlickStorageDriver extends StorageDriver {
     def id: Rep[AggregateType#IdType#IdValueType]
     type TableElementType = RecordType
   }
-  override type SingleResultType[A] = Option[A]
-  override type IOContextType       = SlickFutureIOContext
+
   protected val dao: TableQuery[TableType]
 }


### PR DESCRIPTION
`DSL[_]` が高階なので、 implicit に IOContextType を取らないほうがシンプルになるのでは… をやってみました